### PR TITLE
Filter non safe runes from summary

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"strings"
 	"text/template"
+	"unicode"
 )
 
 const jql = `project in (ROX)
@@ -284,7 +285,11 @@ func (tc testCase) description() (string, error) {
 }
 
 func (tc testCase) summary() (string, error) {
-	return render(tc, summaryTpl)
+	s, err := render(tc, summaryTpl)
+	if err != nil {
+		return "", err
+	}
+	return clearString(s), nil
 }
 
 func render(tc testCase, text string) (string, error) {
@@ -298,4 +303,13 @@ func render(tc testCase, text string) (string, error) {
 		return "", err
 	}
 	return tpl.String(), nil
+}
+
+func clearString(str string) string {
+	return strings.Map(func(r rune) rune {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) || r == '.' || r == '/' || r == '-' || r == '_' {
+			return r
+		}
+		return ' '
+	}, str)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -60,7 +60,7 @@ github.com/stackrox/rox/sensor/kubernetes/localscanner / TestLocalScannerTLSIssu
 			t,
 			[]testCase{
 				{
-					Message: `DefaultPoliciesTest / Verify policy Apache Struts: CVE-2017-5638 is triggered FAILED
+					Message: `DefaultPoliciesTest / Verify policy Apache Struts  CVE-2017-5638 is triggered FAILED
 github.com/stackrox/rox/sensor/kubernetes/localscanner / TestLocalScannerTLSIssuerIntegrationTests FAILED
 github.com/stackrox/rox/sensor/kubernetes/localscanner / TestLocalScannerTLSIssuerIntegrationTests/TestSuccessfulRefresh FAILED
 github.com/stackrox/rox/sensor/kubernetes/localscanner / TestLocalScannerTLSIssuerIntegrationTests/TestSuccessfulRefresh/no_secrets FAILED
@@ -226,5 +226,5 @@ org.spockframework.runtime.ConditionNotSatisfiedError: Condition not satisfied:
 `, actual)
 	s, err := tc.summary()
 	assert.NoError(t, err)
-	assert.Equal(t, `DefaultPoliciesTest / Verify policy Apache Struts: CVE-2017-5638 is triggered FAILED`, s)
+	assert.Equal(t, `DefaultPoliciesTest / Verify policy Apache Struts  CVE-2017-5638 is triggered FAILED`, s)
 }


### PR DESCRIPTION
Some character are not valid chars in query. Let's replace them with ` ` instead of escaping as it's easier and more predictable

See: https://confluence.atlassian.com/jiracoreserver073/search-syntax-for-text-fields-861257223.html#PerformingTextSearches-EscapingSpecialCharactersor