### PR TITLE
Group sub-tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 junit2jira
+.idea

--- a/main.go
+++ b/main.go
@@ -297,12 +297,11 @@ type testCase struct {
 func NewTestCase(tc junit.Test, env map[string]string) testCase {
 	jobSpec := env["JOB_SPEC"]
 	baseLink := gjson.Get(jobSpec, "refs.base_link").String()
-	return testCase{
+	c := testCase{
 		Name:         tc.Name,
 		Message:      tc.Message,
 		Stdout:       tc.SystemOut,
 		Stderr:       tc.SystemErr,
-		Error:        tc.Error.Error(),
 		Suite:        tc.Classname,
 		BuildId:      env["BUILD_ID"],
 		Cluster:      env["CLUSTER_NAME"],
@@ -311,6 +310,11 @@ func NewTestCase(tc junit.Test, env map[string]string) testCase {
 		BuildTag:     env["STACKROX_BUILD_TAG"],
 		BaseLink:     baseLink,
 	}
+
+	if tc.Error != nil {
+		c.Error = tc.Error.Error()
+	}
+	return c
 }
 
 func (tc *testCase) description() (string, error) {

--- a/main.go
+++ b/main.go
@@ -263,7 +263,7 @@ const (
 {{ .Stdout }}
 {code}
 {{- end }}
-{{-if .Error }}
+{{- if .Error }}
 {code:title=ERROR|borderStyle=solid}
 {{ .Error }}
 {code}

--- a/main.go
+++ b/main.go
@@ -263,6 +263,11 @@ const (
 {{ .Stdout }}
 {code}
 {{- end }}
+{{-if .Error }}
+{code:title=ERROR|borderStyle=solid}
+{{ .Error }}
+{code}
+{{- end }}
 
 ||    ENV     ||      Value           ||
 | BUILD ID     | [{{- .BuildId -}}|https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/{{- .JobName -}}/{{- .BuildId -}}]|

--- a/main.go
+++ b/main.go
@@ -236,7 +236,7 @@ func addSubTestToFailedTest(subTest junit.Test, failedTests []testCase, env map[
 	name := strings.Split(subTest.Name, "/")[0]
 	for i, failedTest := range failedTests {
 		// Only consider a failed test a "parent" of the test if the name matches _and_ the class name is the same.
-		if failedTest.Name == name && failedTest.Suite == subTest.Classname {
+		if isGoTest(subTest.Classname) && failedTest.Name == name && failedTest.Suite == subTest.Classname {
 			failedTest.addSubTest(subTest)
 			failedTests[i] = failedTest
 			return failedTests
@@ -244,6 +244,11 @@ func addSubTestToFailedTest(subTest junit.Test, failedTests []testCase, env map[
 	}
 	// In case we found no matches, we will default to add the subtest plain.
 	return append(failedTests, NewTestCase(subTest, env))
+}
+
+// isGoTest will verify that the corresponding classname refers to a go package by expecting the go module name as prefix.
+func isGoTest(className string) bool {
+	return strings.HasPrefix(className, "github.com/stackrox/rox")
 }
 
 const (

--- a/main_test.go
+++ b/main_test.go
@@ -36,17 +36,16 @@ func TestParseJunitReport(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, []testCase{
 			{
-				Message: `github.com/stackrox/rox/sensor/kubernetes/localscanner / TestLocalScannerTLSIssuerIntegrationTests FAILED
-github.com/stackrox/rox/sensor/kubernetes/localscanner / TestLocalScannerTLSIssuerIntegrationTests/TestSuccessfulRefresh FAILED
-github.com/stackrox/rox/sensor/kubernetes/localscanner / TestLocalScannerTLSIssuerIntegrationTests/TestSuccessfulRefresh/no_secrets FAILED
+				Message: `github.com/stackrox/rox/pkg/booleanpolicy/evaluator / TestDifferentBaseTypes FAILED
+github.com/stackrox/rox/sensor/kubernetes/localscanner / TestLocalScannerTLSIssuerIntegrationTests FAILED
 `,
 				JobName: "job-name",
-				Suite:   "github.com/stackrox/rox/sensor/kubernetes/localscanner",
+				Suite:   "",
 			},
 		}, tests)
 	})
 	t.Run("dir multiple suites with threshold", func(t *testing.T) {
-		tests, err := findFailedTests("testdata", map[string]string{"JOB_NAME": "job-name", "BUILD_ID": "1"}, 5)
+		tests, err := findFailedTests("testdata", map[string]string{"JOB_NAME": "job-name", "BUILD_ID": "1"}, 3)
 		assert.NoError(t, err)
 
 		assert.ElementsMatch(
@@ -54,11 +53,9 @@ github.com/stackrox/rox/sensor/kubernetes/localscanner / TestLocalScannerTLSIssu
 			[]testCase{
 				{
 					Message: `DefaultPoliciesTest / Verify policy Apache Struts  CVE-2017-5638 is triggered FAILED
+github.com/stackrox/rox/pkg/booleanpolicy/evaluator / TestDifferentBaseTypes FAILED
 github.com/stackrox/rox/sensor/kubernetes/localscanner / TestLocalScannerTLSIssuerIntegrationTests FAILED
-github.com/stackrox/rox/sensor/kubernetes/localscanner / TestLocalScannerTLSIssuerIntegrationTests/TestSuccessfulRefresh FAILED
-github.com/stackrox/rox/sensor/kubernetes/localscanner / TestLocalScannerTLSIssuerIntegrationTests/TestSuccessfulRefresh/no_secrets FAILED
 github.com/stackrox/rox/central/resourcecollection/datastore/store/postgres / TestCollectionsStore FAILED
-github.com/stackrox/rox/central/resourcecollection/datastore/store/postgres / TestCollectionsStore/TestStore FAILED
 `,
 					JobName: "job-name",
 					BuildId: "1",

--- a/main_test.go
+++ b/main_test.go
@@ -16,24 +16,17 @@ func TestParseJunitReport(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, []testCase{
 			{
+				Name:    "TestDifferentBaseTypes",
+				Suite:   "github.com/stackrox/rox/pkg/booleanpolicy/evaluator",
+				Message: "Failed\nSub test TestDifferentBaseTypes/base_ts,_query_by_relative,_does_not_match: Failed\nSub test TestDifferentBaseTypes/base_ts,_query_by_relative,_does_not_match/on_fully_hydrated_object: Failed\nSub test TestDifferentBaseTypes/base_ts,_query_by_relative,_does_not_match/on_augmented_object: Failed",
+				Error:   "Failed\nSub test TestDifferentBaseTypes/base_ts,_query_by_relative,_does_not_match: Failed\nSub test TestDifferentBaseTypes/base_ts,_query_by_relative,_does_not_match/on_fully_hydrated_object: \n         evaluator_test.go:96: Error Trace: /go/src/github.com/stackrox/stackrox/pkg/booleanpolicy/evaluator/evaluator_test.go:96 /go/src/github.com/stackrox/stackrox/pkg/booleanpolicy/evaluator/evaluator_test.go:123 Error: Not equal: expected: false actual : true Test: TestDifferentBaseTypes/base_ts,_query_by_relative,_does_not_match/on_fully_hydrated_object \n    \nSub test TestDifferentBaseTypes/base_ts,_query_by_relative,_does_not_match/on_augmented_object: \n         evaluator_test.go:96: Error Trace: /go/src/github.com/stackrox/stackrox/pkg/booleanpolicy/evaluator/evaluator_test.go:96 /go/src/github.com/stackrox/stackrox/pkg/booleanpolicy/evaluator/evaluator_test.go:145 Error: Not equal: expected: false actual : true Test: TestDifferentBaseTypes/base_ts,_query_by_relative,_does_not_match/on_augmented_object \n    ",
+			},
+			{
 				Name:    "TestLocalScannerTLSIssuerIntegrationTests",
-				Message: "Failed",
+				Message: "Failed\nSub test TestLocalScannerTLSIssuerIntegrationTests/TestSuccessfulRefresh: Failed\nSub test TestLocalScannerTLSIssuerIntegrationTests/TestSuccessfulRefresh/no_secrets: Failed",
 				Stdout:  "",
 				Stderr:  "",
-				Suite:   "github.com/stackrox/rox/sensor/kubernetes/localscanner",
-			},
-			{
-				Name:    "TestLocalScannerTLSIssuerIntegrationTests/TestSuccessfulRefresh",
-				Message: "Failed",
-				Stdout:  "",
-				Stderr:  "",
-				Suite:   "github.com/stackrox/rox/sensor/kubernetes/localscanner",
-			},
-			{
-				Name:    "TestLocalScannerTLSIssuerIntegrationTests/TestSuccessfulRefresh/no_secrets",
-				Message: "Failed",
-				Stdout:  "",
-				Stderr:  "",
+				Error:   "    env_isolator.go:41: EnvIsolator: Setting ROX_MTLS_CA_FILE to /go/src/github.com/stackrox/stackrox/pkg/mtls/testutils/testdata/central-certs/ca.pem\n    env_isolator.go:41: EnvIsolator: Setting ROX_MTLS_CA_KEY_FILE to /go/src/github.com/stackrox/stackrox/pkg/mtls/testutils/testdata/central-certs/ca-key.pem\n    env_isolator.go:41: EnvIsolator: Setting ROX_MTLS_CERT_FILE to /go/src/github.com/stackrox/stackrox/pkg/mtls/testutils/testdata/central-certs/leaf-cert.pem\n    env_isolator.go:41: EnvIsolator: Setting ROX_MTLS_KEY_FILE to /go/src/github.com/stackrox/stackrox/pkg/mtls/testutils/testdata/central-certs/leaf-key.pem\n    env_isolator.go:41: EnvIsolator: Setting ROX_MTLS_CA_FILE to /go/src/github.com/stackrox/stackrox/pkg/mtls/testutils/testdata/central-certs/ca.pem\n    env_isolator.go:41: EnvIsolator: Setting ROX_MTLS_CA_KEY_FILE to /go/src/github.com/stackrox/stackrox/pkg/mtls/testutils/testdata/central-certs/ca-key.pem\n    env_isolator.go:41: EnvIsolator: Setting ROX_MTLS_CERT_FILE to /go/src/github.com/stackrox/stackrox/pkg/mtls/testutils/testdata/central-certs/leaf-cert.pem\n    env_isolator.go:41: EnvIsolator: Setting ROX_MTLS_KEY_FILE to /go/src/github.com/stackrox/stackrox/pkg/mtls/testutils/testdata/central-certs/leaf-key.pem\nSub test TestLocalScannerTLSIssuerIntegrationTests/TestSuccessfulRefresh: Failed\nSub test TestLocalScannerTLSIssuerIntegrationTests/TestSuccessfulRefresh/no_secrets:     tls_issuer_test.go:377:\n        \tError Trace:\t/go/src/github.com/stackrox/stackrox/sensor/kubernetes/localscanner/tls_issuer_test.go:377\n        \t            \t\t\t\t/go/src/github.com/stackrox/stackrox/sensor/kubernetes/localscanner/tls_issuer_test.go:298\n        \t            \t\t\t\t/go/src/github.com/stackrox/stackrox/sensor/kubernetes/localscanner/suite.go:91\n        \tError:      \tcontext deadline exceeded\n        \tTest:       \tTestLocalScannerTLSIssuerIntegrationTests/TestSuccessfulRefresh/no_secrets\nkubernetes/localscanner: 2022/10/03 07:32:47.446934 cert_refresher.go:109: Warn: local scanner certificates not found (this is expected on a new deployment), will refresh certificates immediately: 2 errors occurred:\n\t* secrets \"scanner-tls\" not found\n\t* secrets \"scanner-db-tls\" not found\n\n",
 				Suite:   "github.com/stackrox/rox/sensor/kubernetes/localscanner",
 			},
 		}, tests)
@@ -107,35 +100,33 @@ github.com/stackrox/rox/central/resourcecollection/datastore/store/postgres / Te
 						"Exit: 0\n",
 					Suite:   "DefaultPoliciesTest",
 					BuildId: "1",
+					Error: "Condition not satisfied:\n" +
+						"\n" +
+						"waitForViolation(deploymentName,  policyName, 60)\n" +
+						"|                |                |\n" +
+						"false            qadefpolstruts   Apache Struts: CVE-2017-5638\n" +
+						"\n" +
+						"\tat DefaultPoliciesTest.Verify policy #policyName is triggered(DefaultPoliciesTest.groovy:181)\n",
+				},
+				{
+					Name:    "TestDifferentBaseTypes",
+					Suite:   "github.com/stackrox/rox/pkg/booleanpolicy/evaluator",
+					Message: "Failed\nSub test TestDifferentBaseTypes/base_ts,_query_by_relative,_does_not_match: Failed\nSub test TestDifferentBaseTypes/base_ts,_query_by_relative,_does_not_match/on_fully_hydrated_object: Failed\nSub test TestDifferentBaseTypes/base_ts,_query_by_relative,_does_not_match/on_augmented_object: Failed",
+					Error:   "Failed\nSub test TestDifferentBaseTypes/base_ts,_query_by_relative,_does_not_match: Failed\nSub test TestDifferentBaseTypes/base_ts,_query_by_relative,_does_not_match/on_fully_hydrated_object: \n         evaluator_test.go:96: Error Trace: /go/src/github.com/stackrox/stackrox/pkg/booleanpolicy/evaluator/evaluator_test.go:96 /go/src/github.com/stackrox/stackrox/pkg/booleanpolicy/evaluator/evaluator_test.go:123 Error: Not equal: expected: false actual : true Test: TestDifferentBaseTypes/base_ts,_query_by_relative,_does_not_match/on_fully_hydrated_object \n    \nSub test TestDifferentBaseTypes/base_ts,_query_by_relative,_does_not_match/on_augmented_object: \n         evaluator_test.go:96: Error Trace: /go/src/github.com/stackrox/stackrox/pkg/booleanpolicy/evaluator/evaluator_test.go:96 /go/src/github.com/stackrox/stackrox/pkg/booleanpolicy/evaluator/evaluator_test.go:145 Error: Not equal: expected: false actual : true Test: TestDifferentBaseTypes/base_ts,_query_by_relative,_does_not_match/on_augmented_object \n    ",
+					BuildId: "1",
 				},
 				{
 					Name:    "TestLocalScannerTLSIssuerIntegrationTests",
-					Message: "Failed",
+					Message: "Failed\nSub test TestLocalScannerTLSIssuerIntegrationTests/TestSuccessfulRefresh: Failed\nSub test TestLocalScannerTLSIssuerIntegrationTests/TestSuccessfulRefresh/no_secrets: Failed",
 					Suite:   "github.com/stackrox/rox/sensor/kubernetes/localscanner",
-					BuildId: "1",
-				},
-				{
-					Name:    "TestLocalScannerTLSIssuerIntegrationTests/TestSuccessfulRefresh",
-					Message: "Failed",
-					Suite:   "github.com/stackrox/rox/sensor/kubernetes/localscanner",
-					BuildId: "1",
-				},
-				{
-					Name:    "TestLocalScannerTLSIssuerIntegrationTests/TestSuccessfulRefresh/no_secrets",
-					Message: "Failed",
-					Suite:   "github.com/stackrox/rox/sensor/kubernetes/localscanner",
+					Error:   "    env_isolator.go:41: EnvIsolator: Setting ROX_MTLS_CA_FILE to /go/src/github.com/stackrox/stackrox/pkg/mtls/testutils/testdata/central-certs/ca.pem\n    env_isolator.go:41: EnvIsolator: Setting ROX_MTLS_CA_KEY_FILE to /go/src/github.com/stackrox/stackrox/pkg/mtls/testutils/testdata/central-certs/ca-key.pem\n    env_isolator.go:41: EnvIsolator: Setting ROX_MTLS_CERT_FILE to /go/src/github.com/stackrox/stackrox/pkg/mtls/testutils/testdata/central-certs/leaf-cert.pem\n    env_isolator.go:41: EnvIsolator: Setting ROX_MTLS_KEY_FILE to /go/src/github.com/stackrox/stackrox/pkg/mtls/testutils/testdata/central-certs/leaf-key.pem\n    env_isolator.go:41: EnvIsolator: Setting ROX_MTLS_CA_FILE to /go/src/github.com/stackrox/stackrox/pkg/mtls/testutils/testdata/central-certs/ca.pem\n    env_isolator.go:41: EnvIsolator: Setting ROX_MTLS_CA_KEY_FILE to /go/src/github.com/stackrox/stackrox/pkg/mtls/testutils/testdata/central-certs/ca-key.pem\n    env_isolator.go:41: EnvIsolator: Setting ROX_MTLS_CERT_FILE to /go/src/github.com/stackrox/stackrox/pkg/mtls/testutils/testdata/central-certs/leaf-cert.pem\n    env_isolator.go:41: EnvIsolator: Setting ROX_MTLS_KEY_FILE to /go/src/github.com/stackrox/stackrox/pkg/mtls/testutils/testdata/central-certs/leaf-key.pem\nSub test TestLocalScannerTLSIssuerIntegrationTests/TestSuccessfulRefresh: Failed\nSub test TestLocalScannerTLSIssuerIntegrationTests/TestSuccessfulRefresh/no_secrets:     tls_issuer_test.go:377:\n        \tError Trace:\t/go/src/github.com/stackrox/stackrox/sensor/kubernetes/localscanner/tls_issuer_test.go:377\n        \t            \t\t\t\t/go/src/github.com/stackrox/stackrox/sensor/kubernetes/localscanner/tls_issuer_test.go:298\n        \t            \t\t\t\t/go/src/github.com/stackrox/stackrox/sensor/kubernetes/localscanner/suite.go:91\n        \tError:      \tcontext deadline exceeded\n        \tTest:       \tTestLocalScannerTLSIssuerIntegrationTests/TestSuccessfulRefresh/no_secrets\nkubernetes/localscanner: 2022/10/03 07:32:47.446934 cert_refresher.go:109: Warn: local scanner certificates not found (this is expected on a new deployment), will refresh certificates immediately: 2 errors occurred:\n\t* secrets \"scanner-tls\" not found\n\t* secrets \"scanner-db-tls\" not found\n\n",
 					BuildId: "1",
 				},
 				{
 					Name:    "TestCollectionsStore",
 					Suite:   "github.com/stackrox/rox/central/resourcecollection/datastore/store/postgres",
-					Message: "Failed",
-					BuildId: "1",
-				},
-				{
-					Name:    "TestCollectionsStore/TestStore",
-					Suite:   "github.com/stackrox/rox/central/resourcecollection/datastore/store/postgres",
-					Message: "Failed",
+					Message: "Failed\nSub test TestCollectionsStore/TestStore: Failed",
+					Error:   "    env_isolator.go:41: EnvIsolator: Setting ROX_POSTGRES_DATASTORE to true\nSub test TestCollectionsStore/TestStore:     store_test.go:47: collections TRUNCATE TABLE\n    store_test.go:95:\n        \tError Trace:\t/go/src/github.com/stackrox/stackrox/central/resourcecollection/datastore/store/postgres/store_test.go:95\n        \tError:      \tReceived unexpected error:\n        \t            \tERROR: update or delete on table \"collections\" violates foreign key constraint \"fk_collections_embedded_collections_collections_cycle_ref\" on table \"collections_embedded_collections\" (SQLSTATE 23503)\n        \t            \tcould not delete from \"collections\"\n        \t            \tgithub.com/stackrox/rox/pkg/search/postgres.RunDeleteRequestForSchema.func1\n        \t            \t\t/go/src/github.com/stackrox/stackrox/pkg/search/postgres/common.go:833\n        \t            \tgithub.com/stackrox/rox/pkg/postgres/pgutils.Retry.func1\n        \t            \t\t/go/src/github.com/stackrox/stackrox/pkg/postgres/pgutils/retry.go:21\n        \t            \tgithub.com/stackrox/rox/pkg/postgres/pgutils.Retry2[...].func1\n        \t            \t\t/go/src/github.com/stackrox/stackrox/pkg/postgres/pgutils/retry.go:32\n        \t            \tgithub.com/stackrox/rox/pkg/postgres/pgutils.Retry3[...]\n        \t            \t\t/go/src/github.com/stackrox/stackrox/pkg/postgres/pgutils/retry.go:43\n        \t            \tgithub.com/stackrox/rox/pkg/postgres/pgutils.Retry2[...]\n        \t            \t\t/go/src/github.com/stackrox/stackrox/pkg/postgres/pgutils/retry.go:35\n        \t            \tgithub.com/stackrox/rox/pkg/postgres/pgutils.Retry\n        \t            \t\t/go/src/github.com/stackrox/stackrox/pkg/postgres/pgutils/retry.go:23\n        \t            \tgithub.com/stackrox/rox/pkg/search/postgres.RunDeleteRequestForSchema\n        \t            \t\t/go/src/github.com/stackrox/stackrox/pkg/search/postgres/common.go:830\n        \t            \tgithub.com/stackrox/rox/central/resourcecollection/datastore/store/postgres.(*storeImpl).Delete\n        \t            \t\t/go/src/github.com/stackrox/stackrox/central/resourcecollection/datastore/store/postgres/store.go:429\n        \t            \tgithub.com/stackrox/rox/central/resourcecollection/datastore/store/postgres.(*CollectionsStoreSuite).TestStore\n        \t            \t\t/go/src/github.com/stackrox/stackrox/central/resourcecollection/datastore/store/postgres/store_test.go:95\n        \t            \treflect.Value.call\n        \t            \t\t/usr/local/go/src/reflect/value.go:556\n        \t            \treflect.Value.Call\n        \t            \t\t/usr/local/go/src/reflect/value.go:339\n        \t            \tgithub.com/stretchr/testify/suite.Run.func1\n        \t            \t\t/go/pkg/mod/github.com/stretchr/testify@v1.8.0/suite/suite.go:175\n        \t            \ttesting.tRunner\n        \t            \t\t/usr/local/go/src/testing/testing.go:1439\n        \t            \truntime.goexit\n        \t            \t\t/usr/local/go/src/runtime/asm_amd64.s:1571\n        \tTest:       \tTestCollectionsStore/TestStore\n    store_test.go:98:\n        \tError Trace:\t/go/src/github.com/stackrox/stackrox/central/resourcecollection/datastore/store/postgres/store_test.go:98\n        \tError:      \tShould be false\n        \tTest:       \tTestCollectionsStore/TestStore\n    store_test.go:99:\n        \tError Trace:\t/go/src/github.com/stackrox/stackrox/central/resourcecollection/datastore/store/postgres/store_test.go:99\n        \tError:      \tExpected nil, but got: &storage.ResourceCollection{Id:\"a\", Name:\"a\", Description:\"a\", CreatedAt:&types.Timestamp{Seconds: 1,\n        \t            \tNanos: 1,\n        \t            \t}, LastUpdated:&types.Timestamp{Seconds: 1,\n        \t            \tNanos: 1,\n        \t            \t}, CreatedBy:(*storage.SlimUser)(0xc00085fb00), UpdatedBy:(*storage.SlimUser)(0xc00085fb40), ResourceSelectors:[]*storage.ResourceSelector{(*storage.ResourceSelector)(0xc00085fb80)}, EmbeddedCollections:[]*storage.ResourceCollection_EmbeddedResourceCollection{(*storage.ResourceCollection_EmbeddedResourceCollection)(0xc0011e00f0)}, XXX_NoUnkeyedLiteral:struct {}{}, XXX_unrecognized:[]uint8(nil), XXX_sizecache:0}\n        \tTest:       \tTestCollectionsStore/TestStore\n    store_test.go:114:\n        \tError Trace:\t/go/src/github.com/stackrox/stackrox/central/resourcecollection/datastore/store/postgres/store_test.go:114\n        \tError:      \tNot equal:\n        \t            \texpected: 200\n        \t            \tactual  : 201\n        \tTest:       \tTestCollectionsStore/TestStore",
 					BuildId: "1",
 				},
 			},
@@ -175,6 +166,13 @@ github.com/stackrox/rox/central/resourcecollection/datastore/store/postgres / Te
 				Stderr:  "",
 				Suite:   "DefaultPoliciesTest",
 				BuildId: "1",
+				Error: "Condition not satisfied:\n" +
+					"\n" +
+					"waitForViolation(deploymentName,  policyName, 60)\n" +
+					"|                |                |\n" +
+					"false            qadefpolstruts   Apache Struts: CVE-2017-5638\n" +
+					"\n" +
+					"\tat DefaultPoliciesTest.Verify policy #policyName is triggered(DefaultPoliciesTest.groovy:181)\n",
 			}},
 			tests,
 		)

--- a/testdata/report.xml
+++ b/testdata/report.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites tests="10849" failures="3" skipped="63">
+<testsuites tests="10849" failures="7" skipped="63">
 	<testsuite name="github.com/stackrox/rox/central/activecomponent/datastore/index" tests="2" failures="0" errors="0" id="0" hostname="merge-go-unit-tests-release-stackrox-initial" time="0.563" timestamp="2022-10-03T07:33:22Z">
 		<properties>
 			<property name="coverage.statements.pct" value="66.70"></property>
@@ -10735,138 +10735,150 @@ ok  	github.com/stackrox/rox/pkg/bolthelper/tests	0.083s	coverage: [no statement
 		<testcase name="TestCompound/simple_compound_query,_AND,_negated,_matches" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
 		<testcase name="TestCompound/simple_compound_query,_AND,_negated,_matches/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
 		<testcase name="TestCompound/simple_compound_query,_AND,_negated,_matches/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.020"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_ptr,_null_query,_nil_pointer" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_ptr,_null_query,_nil_pointer/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_ptr,_null_query,_nil_pointer/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_ptr,_not_null_query,_nil_pointer" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_ptr,_not_null_query,_nil_pointer/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_ptr,_not_null_query,_nil_pointer/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_ptr,_null_query,_non-nil" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_ptr,_null_query,_non-nil/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_ptr,_null_query,_non-nil/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_ptr,_not_null_query,_non-nil" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_ptr,_not_null_query,_non-nil/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_ptr,_not_null_query,_non-nil/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_ptr,_regular_string_query,_matches" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_ptr,_regular_string_query,_matches/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_ptr,_regular_string_query,_matches/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_ptr,_regular_string_query,_does_not_match" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_ptr,_regular_string_query,_does_not_match/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_ptr,_regular_string_query,_does_not_match/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_bool,_should_match" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_bool,_should_match/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_bool,_should_match/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_bool,_should_not_match" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_bool,_should_not_match/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_bool,_should_not_match/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_bool,_with_negation" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_bool,_with_negation/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_bool,_with_negation/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_ts,_null,_matches" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_ts,_null,_matches/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_ts,_null,_matches/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_ts,_null_query,_does_not_match" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_ts,_null_query,_does_not_match/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_ts,_null_query,_does_not_match/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_ts,_null_ts,_but_valid_query,_does_not_match" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_ts,_null_ts,_but_valid_query,_does_not_match/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_ts,_null_ts,_but_valid_query,_does_not_match/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_ts,_null_ts,_not_null_query,_does_not_match" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_ts,_null_ts,_not_null_query,_does_not_match/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_ts,_null_ts,_not_null_query,_does_not_match/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_ts,_null_ts,_but_valid_query,_negated,_does_not_match" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_ts,_null_ts,_but_valid_query,_negated,_does_not_match/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_ts,_null_ts,_but_valid_query,_negated,_does_not_match/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_ts,_valid_ts,_not_null_query,_matches" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_ts,_valid_ts,_not_null_query,_matches/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_ts,_valid_ts,_not_null_query,_matches/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_ts,_query_by_absolute,_matches" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_ts,_query_by_absolute,_matches/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_ts,_query_by_absolute,_matches/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_ts,_query_by_absolute,_does_not_match" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_ts,_query_by_absolute,_does_not_match/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_ts,_query_by_absolute,_does_not_match/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_ts,_query_by_absolute,_negate" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_ts,_query_by_absolute,_negate/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_ts,_query_by_absolute,_negate/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_ts,_query_by_relative,_matches" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_ts,_query_by_relative,_matches/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_ts,_query_by_relative,_matches/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_ts,_query_by_relative,_does_not_match" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_ts,_query_by_relative,_does_not_match/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_ts,_query_by_relative,_does_not_match/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_int,_matches" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_int,_matches/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_int,_matches/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_int,_does_not_match" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_int,_does_not_match/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_int,_does_not_match/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_uint,_matches" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_uint,_matches/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_uint,_matches/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_uint,_does_not_match" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_uint,_does_not_match/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_uint,_does_not_match/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_float,_matches_and_is_a_whole_number" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_float,_matches_and_is_a_whole_number/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_float,_matches_and_is_a_whole_number/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_float,_exact_match" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_float,_exact_match/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_float,_exact_match/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_float,_matches" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_float,_matches/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_float,_matches/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_float,_does_not_match" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_float,_does_not_match/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_float,_does_not_match/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_enum,_exact,_matches" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_enum,_exact,_matches/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_enum,_exact,_matches/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_enum,_exact,_does_not_match" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_enum,_exact,_does_not_match/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_enum,_exact,_does_not_match/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_enum,_range,_matches" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_enum,_range,_matches/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_enum,_range,_matches/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_enum,_range,_does_not_match" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_enum,_range,_does_not_match/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_enum,_range,_does_not_match/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_enum,_complex_range,_matches" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_enum,_complex_range,_matches/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_enum,_complex_range,_matches/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_enum,_complex_range,_does_not_match" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_enum,_complex_range,_does_not_match/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_enum,_complex_range,_does_not_match/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_struct_ptr,_nil,_matches" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_struct_ptr,_nil,_matches/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_struct_ptr,_nil,_matches/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_struct_ptr,_not_nil,_does_not_match" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_struct_ptr,_not_nil,_does_not_match/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_struct_ptr,_not_nil,_does_not_match/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_struct_ptr,_nil,_negated,_does_not_match" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_struct_ptr,_nil,_negated,_does_not_match/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_struct_ptr,_nil,_negated,_does_not_match/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_struct_ptr,_not_nil,_negated,_matches" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_struct_ptr,_not_nil,_negated,_matches/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypes/base_struct_ptr,_not_nil,_negated,_matches/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypesMatchAll" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypesMatchAll/base_ptr,_nil_pointer" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypesMatchAll/base_ptr,_nil_pointer/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypesMatchAll/base_ptr,_nil_pointer/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypesMatchAll/base_ptr,_nil_pointer,_no_match" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypesMatchAll/base_ptr,_nil_pointer,_no_match/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypesMatchAll/base_ptr,_nil_pointer,_no_match/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypesMatchAll/base_ptr,_nil_pointer,_negated" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypesMatchAll/base_ptr,_nil_pointer,_negated/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypesMatchAll/base_ptr,_nil_pointer,_negated/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypesMatchAll/base_ptr,_nil_pointer,_negated,_no_match" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypesMatchAll/base_ptr,_nil_pointer,_negated,_no_match/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypesMatchAll/base_ptr,_nil_pointer,_negated,_no_match/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypesMatchAll/base_ptr,_not_null_query,_match" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypesMatchAll/base_ptr,_not_null_query,_match/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-		<testcase name="TestDifferentBaseTypesMatchAll/base_ptr,_not_null_query,_match/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"></testcase>
-	</testsuite>
+<testcase name="TestDifferentBaseTypes" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.050">
+    <failure message="Failed"/>
+</testcase>
+<testcase name="TestDifferentBaseTypes/base_ptr,_null_query,_nil_pointer" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_ptr,_null_query,_nil_pointer/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_ptr,_null_query,_nil_pointer/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_ptr,_not_null_query,_nil_pointer" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_ptr,_not_null_query,_nil_pointer/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_ptr,_not_null_query,_nil_pointer/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_ptr,_null_query,_non-nil" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_ptr,_null_query,_non-nil/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_ptr,_null_query,_non-nil/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_ptr,_not_null_query,_non-nil" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_ptr,_not_null_query,_non-nil/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_ptr,_not_null_query,_non-nil/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_ptr,_regular_string_query,_matches" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_ptr,_regular_string_query,_matches/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_ptr,_regular_string_query,_matches/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_ptr,_regular_string_query,_does_not_match" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_ptr,_regular_string_query,_does_not_match/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_ptr,_regular_string_query,_does_not_match/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_bool,_should_match" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_bool,_should_match/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_bool,_should_match/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_bool,_should_not_match" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_bool,_should_not_match/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_bool,_should_not_match/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_bool,_with_negation" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_bool,_with_negation/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_bool,_with_negation/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_ts,_null,_matches" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_ts,_null,_matches/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_ts,_null,_matches/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_ts,_null_query,_does_not_match" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_ts,_null_query,_does_not_match/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_ts,_null_query,_does_not_match/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_ts,_null_ts,_but_valid_query,_does_not_match" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_ts,_null_ts,_but_valid_query,_does_not_match/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_ts,_null_ts,_but_valid_query,_does_not_match/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_ts,_null_ts,_not_null_query,_does_not_match" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_ts,_null_ts,_not_null_query,_does_not_match/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_ts,_null_ts,_not_null_query,_does_not_match/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_ts,_null_ts,_but_valid_query,_negated,_does_not_match" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_ts,_null_ts,_but_valid_query,_negated,_does_not_match/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_ts,_null_ts,_but_valid_query,_negated,_does_not_match/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_ts,_valid_ts,_not_null_query,_matches" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_ts,_valid_ts,_not_null_query,_matches/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_ts,_valid_ts,_not_null_query,_matches/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_ts,_query_by_absolute,_matches" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_ts,_query_by_absolute,_matches/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_ts,_query_by_absolute,_matches/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_ts,_query_by_absolute,_does_not_match" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_ts,_query_by_absolute,_does_not_match/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_ts,_query_by_absolute,_does_not_match/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_ts,_query_by_absolute,_negate" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_ts,_query_by_absolute,_negate/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_ts,_query_by_absolute,_negate/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_ts,_query_by_relative,_matches" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_ts,_query_by_relative,_matches/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_ts,_query_by_relative,_matches/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_ts,_query_by_relative,_does_not_match" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000">
+    <failure message="Failed"/>
+</testcase>
+<testcase name="TestDifferentBaseTypes/base_ts,_query_by_relative,_does_not_match/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000">
+    <failure message="Failed">
+        <![CDATA[ evaluator_test.go:96: Error Trace: /go/src/github.com/stackrox/stackrox/pkg/booleanpolicy/evaluator/evaluator_test.go:96 /go/src/github.com/stackrox/stackrox/pkg/booleanpolicy/evaluator/evaluator_test.go:123 Error: Not equal: expected: false actual : true Test: TestDifferentBaseTypes/base_ts,_query_by_relative,_does_not_match/on_fully_hydrated_object ]]>
+    </failure>
+</testcase>
+<testcase name="TestDifferentBaseTypes/base_ts,_query_by_relative,_does_not_match/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000">
+    <failure message="Failed">
+        <![CDATA[ evaluator_test.go:96: Error Trace: /go/src/github.com/stackrox/stackrox/pkg/booleanpolicy/evaluator/evaluator_test.go:96 /go/src/github.com/stackrox/stackrox/pkg/booleanpolicy/evaluator/evaluator_test.go:145 Error: Not equal: expected: false actual : true Test: TestDifferentBaseTypes/base_ts,_query_by_relative,_does_not_match/on_augmented_object ]]>
+    </failure>
+</testcase>
+<testcase name="TestDifferentBaseTypes/base_int,_matches" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_int,_matches/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_int,_matches/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_int,_does_not_match" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_int,_does_not_match/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_int,_does_not_match/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_uint,_matches" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_uint,_matches/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_uint,_matches/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_uint,_does_not_match" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_uint,_does_not_match/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_uint,_does_not_match/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_float,_matches_and_is_a_whole_number" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_float,_matches_and_is_a_whole_number/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_float,_matches_and_is_a_whole_number/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_float,_exact_match" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_float,_exact_match/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_float,_exact_match/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_float,_matches" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_float,_matches/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_float,_matches/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_float,_does_not_match" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_float,_does_not_match/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_float,_does_not_match/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_enum,_exact,_matches" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.010"/>
+<testcase name="TestDifferentBaseTypes/base_enum,_exact,_matches/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.010"/>
+<testcase name="TestDifferentBaseTypes/base_enum,_exact,_matches/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_enum,_exact,_does_not_match" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_enum,_exact,_does_not_match/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_enum,_exact,_does_not_match/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_enum,_range,_matches" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_enum,_range,_matches/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_enum,_range,_matches/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_enum,_range,_does_not_match" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_enum,_range,_does_not_match/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_enum,_range,_does_not_match/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_enum,_complex_range,_matches" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_enum,_complex_range,_matches/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_enum,_complex_range,_matches/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_enum,_complex_range,_does_not_match" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_enum,_complex_range,_does_not_match/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_enum,_complex_range,_does_not_match/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_struct_ptr,_nil,_matches" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_struct_ptr,_nil,_matches/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_struct_ptr,_nil,_matches/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_struct_ptr,_not_nil,_does_not_match" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_struct_ptr,_not_nil,_does_not_match/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_struct_ptr,_not_nil,_does_not_match/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_struct_ptr,_nil,_negated,_does_not_match" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_struct_ptr,_nil,_negated,_does_not_match/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_struct_ptr,_nil,_negated,_does_not_match/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_struct_ptr,_not_nil,_negated,_matches" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_struct_ptr,_not_nil,_negated,_matches/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypes/base_struct_ptr,_not_nil,_negated,_matches/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypesMatchAll" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.010"/>
+<testcase name="TestDifferentBaseTypesMatchAll/base_ptr,_nil_pointer" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypesMatchAll/base_ptr,_nil_pointer/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypesMatchAll/base_ptr,_nil_pointer/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypesMatchAll/base_ptr,_nil_pointer,_no_match" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypesMatchAll/base_ptr,_nil_pointer,_no_match/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypesMatchAll/base_ptr,_nil_pointer,_no_match/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypesMatchAll/base_ptr,_nil_pointer,_negated" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypesMatchAll/base_ptr,_nil_pointer,_negated/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypesMatchAll/base_ptr,_nil_pointer,_negated/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypesMatchAll/base_ptr,_nil_pointer,_negated,_no_match" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypesMatchAll/base_ptr,_nil_pointer,_negated,_no_match/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypesMatchAll/base_ptr,_nil_pointer,_negated,_no_match/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypesMatchAll/base_ptr,_not_null_query,_match" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypesMatchAll/base_ptr,_not_null_query,_match/on_fully_hydrated_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+<testcase name="TestDifferentBaseTypesMatchAll/base_ptr,_not_null_query,_match/on_augmented_object" classname="github.com/stackrox/rox/pkg/booleanpolicy/evaluator" time="0.000"/>
+</testsuite>
 	<testsuite name="github.com/stackrox/rox/pkg/booleanpolicy/evaluator/pathutil" tests="32" failures="0" errors="0" id="457" hostname="merge-go-unit-tests-release-stackrox-initial" time="0.112" timestamp="2022-10-03T07:33:22Z">
 		<properties>
 			<property name="coverage.statements.pct" value="85.50"></property>
@@ -17595,7 +17607,8 @@ the login page, and log in with username "admin" and the password found in the
          test-token ]]></system-out>
 		</testcase>
 		<testcase name="TestToken/Test_RetrieveAuthToken_ShouldTrimLeadingAndTrailingWhitespace_Windows" classname="github.com/stackrox/rox/roxctl/common" time="0.000">
-			<system-out><![CDATA[    env_isolator.go:41: EnvIsolator: Setting ROX_API_TOKEN to   test-token ]]></system-out>
+			<system-out><![CDATA[    env_isolator.go:41: EnvIsolator: Setting ROX_API_TOKEN to  
+ test-token ]]></system-out>
 		</testcase>
 		<testcase name="TestToken/Test_RetrieveAuthToken_WithEnv" classname="github.com/stackrox/rox/roxctl/common" time="0.000">
 			<system-out><![CDATA[    env_isolator.go:41: EnvIsolator: Setting ROX_API_TOKEN to test-token]]></system-out>


### PR DESCRIPTION
The PR will allow grouping for sub-tests to avoid creating multiple tickets + adds the `Errors` field to the ticket description which holds more information than the typical `Failed` message we receive.

Closes #4 