### PR TITLE
Truncate text

### DIFF
--- a/main.go
+++ b/main.go
@@ -378,7 +378,7 @@ var maxTextBlockLength = 10000
 func truncate(s string) string {
 	runes := []rune(s)
 	if len(runes) > maxTextBlockLength {
-		return string(runes[:maxTextBlockLength]) + "\n … too long truncated"
+		return string(runes[:maxTextBlockLength]) + "\n … too long, truncated."
 	}
 	return s
 }

--- a/main.go
+++ b/main.go
@@ -255,22 +255,22 @@ const (
 	desc = `
 {{- if .Message }}
 {code:title=Message|borderStyle=solid}
-{{ .Message }}
+{{ .Message | truncate }}
 {code}
 {{- end }}
 {{- if .Stderr }}
 {code:title=STDERR|borderStyle=solid}
-{{ .Stderr }}
+{{ .Stderr | truncate }}
 {code}
 {{- end }}
 {{- if .Stdout }}
 {code:title=STDOUT|borderStyle=solid}
-{{ .Stdout }}
+{{ .Stdout | truncate }}
 {code}
 {{- end }}
 {{- if .Error }}
 {code:title=ERROR|borderStyle=solid}
-{{ .Error }}
+{{ .Error | truncate }}
 {code}
 {{- end }}
 
@@ -352,7 +352,7 @@ func (tc *testCase) addSubTest(subTest junit.Test) {
 }
 
 func render(tc testCase, text string) (string, error) {
-	tmpl, err := template.New("test").Parse(text)
+	tmpl, err := template.New("test").Funcs(map[string]any{"truncate": truncate}).Parse(text)
 	if err != nil {
 		return "", err
 	}
@@ -371,4 +371,14 @@ func clearString(str string) string {
 		}
 		return ' '
 	}, str)
+}
+
+var maxTextBlockLength = 10000
+
+func truncate(s string) string {
+	runes := []rune(s)
+	if len(runes) > maxTextBlockLength {
+		return string(runes[:maxTextBlockLength]) + "\n … too long truncated"
+	}
+	return s
 }

--- a/main_test.go
+++ b/main_test.go
@@ -232,12 +232,12 @@ Condition not satisfied:
 
 waitForViolation(deploymentName,  policyName, 60)
 |                |      
- … too long truncated
+ … too long, truncated.
 {code}
 {code:title=STDOUT|borderStyle=solid}
 ?[1;30m21:35:15?[0;39m | ?[34mINFO ?[0;39m | DefaultPoliciesTest       | Starting testcase
 ?[1;30m21
- … too long truncated
+ … too long, truncated.
 {code}
 
 ||    ENV     ||      Value           ||

--- a/main_test.go
+++ b/main_test.go
@@ -222,4 +222,29 @@ org.spockframework.runtime.ConditionNotSatisfiedError: Condition not satisfied:
 	s, err := tc.summary()
 	assert.NoError(t, err)
 	assert.Equal(t, `DefaultPoliciesTest / Verify policy Apache Struts  CVE-2017-5638 is triggered FAILED`, s)
+
+	maxTextBlockLength = 100
+	actual, err = tc.description()
+	assert.NoError(t, err)
+	assert.Equal(t, `
+{code:title=Message|borderStyle=solid}
+Condition not satisfied:
+
+waitForViolation(deploymentName,  policyName, 60)
+|                |      
+ … too long truncated
+{code}
+{code:title=STDOUT|borderStyle=solid}
+?[1;30m21:35:15?[0;39m | ?[34mINFO ?[0;39m | DefaultPoliciesTest       | Starting testcase
+?[1;30m21
+ … too long truncated
+{code}
+
+||    ENV     ||      Value           ||
+| BUILD ID     | [1|https://prow.ci.openshift.org/view/gs/origin-ci-test/logs//1]|
+| BUILD TAG    | [|]|
+| JOB NAME     ||
+| CLUSTER      ||
+| ORCHESTRATOR ||
+`, actual)
 }


### PR DESCRIPTION
Jira has limit for size of description. This PR will truncate every field to 10k to not hit that limit.

```
2023/02/08 07:25:55 request failed. Please analyze the request body for more details. Status code: 400
2023/02/08 07:25:55 400
2023/02/08 07:25:55 {"errorMessages":[],"errors":{"description":"The entered text is too long. It exceeds the allowed limit of 65,535 characters."}}
2023/02/08 07:25:55 1 error occurred:
	* could not create issue RoutesTest / Verify that routes are detected correctly FAILED: request failed. Please analyze the request body for more details. Status code: 400
```
https://storage.googleapis.com/origin-ci-test/logs/branch-ci-stackrox-stackrox-nightlies-openshift-oldest-qa-e2e-tests/1623185966627819520/build-log.txt