### PR TITLE
ROX-14757: Use job name if multiple suites fails

### DIFF
--- a/main.go
+++ b/main.go
@@ -209,7 +209,7 @@ func mergeFailedTests(failedTests []testCase, env map[string]string) ([]testCase
 		}
 		// If there are multiple suites, do not report them.
 		if suite != t.Suite {
-			suite = ""
+			suite = env["JOB_NAME"]
 		}
 		msg += summary + "\n"
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -40,7 +40,7 @@ func TestParseJunitReport(t *testing.T) {
 github.com/stackrox/rox/sensor/kubernetes/localscanner / TestLocalScannerTLSIssuerIntegrationTests FAILED
 `,
 				JobName: "job-name",
-				Suite:   "",
+				Suite:   "job-name",
 			},
 		}, tests)
 	})
@@ -59,6 +59,7 @@ github.com/stackrox/rox/central/resourcecollection/datastore/store/postgres / Te
 command-line-arguments / TestTimeout FAILED
 `,
 					JobName: "job-name",
+					Suite:   "job-name",
 					BuildId: "1",
 				},
 			},


### PR DESCRIPTION
Currently when multiple suites fails, we use an empty string (`""`) as a batch suite name. This result with creating tasks like `  / FAILED`. To prevent it and keep more context let's use job name as a suite name as it's next in hierarchy. 