### PR TITLE
Truncate summary

### DIFF
--- a/main.go
+++ b/main.go
@@ -281,7 +281,7 @@ const (
 | CLUSTER      | {{- .Cluster -}}      |
 | ORCHESTRATOR | {{- .Orchestrator -}} |
 `
-	summaryTpl = `{{ .Suite }} / {{ .Name }} FAILED`
+	summaryTpl = `{{ (print .Suite " / " .Name) | truncateSummary }} FAILED`
 )
 
 type testCase struct {
@@ -352,7 +352,7 @@ func (tc *testCase) addSubTest(subTest junit.Test) {
 }
 
 func render(tc testCase, text string) (string, error) {
-	tmpl, err := template.New("test").Funcs(map[string]any{"truncate": truncate}).Parse(text)
+	tmpl, err := template.New("test").Funcs(map[string]any{"truncate": truncate, "truncateSummary": truncateSummary}).Parse(text)
 	if err != nil {
 		return "", err
 	}
@@ -379,6 +379,16 @@ func truncate(s string) string {
 	runes := []rune(s)
 	if len(runes) > maxTextBlockLength {
 		return string(runes[:maxTextBlockLength]) + "\n … too long, truncated."
+	}
+	return s
+}
+
+var maxSummaryLength = 200
+
+func truncateSummary(s string) string {
+	runes := []rune(s)
+	if len(runes) > maxSummaryLength {
+		return string(runes[:maxSummaryLength]) + "..."
 	}
 	return s
 }

--- a/main_test.go
+++ b/main_test.go
@@ -232,6 +232,11 @@ org.spockframework.runtime.ConditionNotSatisfiedError: Condition not satisfied:
 	assert.NoError(t, err)
 	assert.Equal(t, `DefaultPoliciesTest / Verify policy Apache Struts  CVE-2017-5638 is triggered FAILED`, s)
 
+	maxSummaryLength = 20
+	s, err = tc.summary()
+	assert.NoError(t, err)
+	assert.Equal(t, `DefaultPoliciesTest ... FAILED`, s)
+
 	maxTextBlockLength = 100
 	actual, err = tc.description()
 	assert.NoError(t, err)


### PR DESCRIPTION
Summary has a limit of 255 characters. This PRs truncated summaries with length greater than 200 and add ellipsis instead to indicate summary was truncated. 