### PR TITLE
Use flags instead of env

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ go test ./...
 ### Usage
 ```shell
 JIRA_TOKEN="..." junit2jira \
-  -jira-url "..." \
+  -jira-url "https://..." \
   -junit-reports-dir "..." \
   -base-link "https://..." \
   -build-id "$BUILD_ID|GITHUB_RUN_ID" \

--- a/README.md
+++ b/README.md
@@ -14,5 +14,13 @@ go test ./...
 
 ### Usage
 ```shell
-JIRA_TOKEN="..." junit2jira -jira-url "..." -junit-reports-dir "..."
+JIRA_TOKEN="..." junit2jira \
+  -jira-url "..." \
+  -junit-reports-dir "..." \
+  -base-link "https://..." \
+  -build-id "$BUILD_ID|GITHUB_RUN_ID" \
+  -build-link "https://..." \
+  -build-tag "$STACKROX_BUILD_TAG|$GITHUB_SHA" \
+  -job-name "$JOB_NAME|$GITHUB_WORKFLOW" \
+  -orchestrator "$ORCHESTRATOR_FLAVOR"
 ```

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/andygrunwald/go-jira v1.16.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/joshdk/go-junit v0.0.0-20210226021600-6145f504ca0d
+	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.0
 )
 
@@ -15,11 +16,7 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.4.2 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/tidwall/gjson v1.14.3 // indirect
-	github.com/tidwall/match v1.1.1 // indirect
-	github.com/tidwall/pretty v1.2.1 // indirect
 	github.com/trivago/tgo v1.0.7 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -28,13 +28,6 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/tidwall/gjson v1.14.3 h1:9jvXn7olKEHU1S9vwoMGliaT8jq1vJ7IH/n9zD9Dnlw=
-github.com/tidwall/gjson v1.14.3/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
-github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
-github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
-github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
-github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
-github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/trivago/tgo v1.0.7 h1:uaWH/XIy9aWYWpjm2CU3RpcqZXmX2ysQ9/Go+d9gyrM=
 github.com/trivago/tgo v1.0.7/go.mod h1:w4dpD+3tzNIIiIfkWWa85w5/B77tlvdZckQ+6PkFnhc=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/main.go
+++ b/main.go
@@ -35,7 +35,6 @@ func main() {
 	flag.StringVar(&junitReportsDir, "junit-reports-dir", os.Getenv("ARTIFACT_DIR"), "Dir that contains jUnit reports XML files")
 	flag.BoolVar(&dryRun, "dry-run", false, "When set to true issues will NOT be created.")
 	flag.IntVar(&threshold, "threshold", 10, "Number of reported failures that should cause single issue creation.")
-
 	flag.StringVar(&p.BaseLink, "base-link", "", "Link to revision")
 	flag.StringVar(&p.BuildId, "build-id", "", "Build job run ID")
 	flag.StringVar(&p.BuildLink, "build-link", "", "Link to build job")

--- a/main.go
+++ b/main.go
@@ -35,12 +35,12 @@ func main() {
 	flag.StringVar(&junitReportsDir, "junit-reports-dir", os.Getenv("ARTIFACT_DIR"), "Dir that contains jUnit reports XML files")
 	flag.BoolVar(&dryRun, "dry-run", false, "When set to true issues will NOT be created.")
 	flag.IntVar(&threshold, "threshold", 10, "Number of reported failures that should cause single issue creation.")
-	flag.StringVar(&p.BaseLink, "base-link", "", "Link to revision")
-	flag.StringVar(&p.BuildId, "build-id", "", "Build job run ID")
-	flag.StringVar(&p.BuildLink, "build-link", "", "Link to build job")
-	flag.StringVar(&p.BuildTag, "build-tag", "", "Built tag or revision")
-	flag.StringVar(&p.JobName, "job-name", "", "Name of CI job")
-	flag.StringVar(&p.Orchestrator, "orchestrator", "", "Orchestrator name")
+	flag.StringVar(&p.BaseLink, "base-link", "", "Link to source code at the exact version under test.")
+	flag.StringVar(&p.BuildId, "build-id", "", "Build job run ID.")
+	flag.StringVar(&p.BuildLink, "build-link", "", "Link to build job.")
+	flag.StringVar(&p.BuildTag, "build-tag", "", "Built tag or revision.")
+	flag.StringVar(&p.JobName, "job-name", "", "Name of CI job.")
+	flag.StringVar(&p.Orchestrator, "orchestrator", "", "Orchestrator name (such as GKE or OpenShift), if any.")
 
 	flag.Parse()
 

--- a/main_test.go
+++ b/main_test.go
@@ -223,7 +223,7 @@ org.spockframework.runtime.ConditionNotSatisfiedError: Condition not satisfied:
 {code}
 
 ||    ENV     ||      Value           ||
-| BUILD ID     | [1|https://prow.ci.openshift.org/view/gs/origin-ci-test/logs//1]|
+| BUILD ID     | [1|https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/1]|
 | BUILD TAG    | [|]|
 | JOB NAME     ||
 | ORCHESTRATOR ||
@@ -250,7 +250,7 @@ waitForViolation(deploymentName,  policyName, 60)
 {code}
 
 ||    ENV     ||      Value           ||
-| BUILD ID     | [1|https://prow.ci.openshift.org/view/gs/origin-ci-test/logs//1]|
+| BUILD ID     | [1|https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/1]|
 | BUILD TAG    | [|]|
 | JOB NAME     ||
 | ORCHESTRATOR ||

--- a/main_test.go
+++ b/main_test.go
@@ -201,7 +201,7 @@ func TestDescription(t *testing.T) {
 		Stderr:    "",
 		Suite:     "DefaultPoliciesTest",
 		BuildId:   "1",
-		BuildLink: "https://prow.ci.openshift.org/view/gs/origin-ci-test/logs//1",
+		BuildLink: "https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/1",
 	}
 	actual, err := tc.description()
 	assert.NoError(t, err)

--- a/main_test.go
+++ b/main_test.go
@@ -7,12 +7,12 @@ import (
 
 func TestParseJunitReport(t *testing.T) {
 	t.Run("not existing", func(t *testing.T) {
-		tests, err := findFailedTests("not existing", nil, 0)
+		tests, err := findFailedTests("not existing", params{}, 0)
 		assert.Error(t, err)
 		assert.Nil(t, tests)
 	})
 	t.Run("golang", func(t *testing.T) {
-		tests, err := findFailedTests("testdata/report.xml", nil, 0)
+		tests, err := findFailedTests("testdata/report.xml", params{}, 0)
 		assert.NoError(t, err)
 		assert.Equal(t, []testCase{
 			{
@@ -32,7 +32,7 @@ func TestParseJunitReport(t *testing.T) {
 		}, tests)
 	})
 	t.Run("golang with threshold", func(t *testing.T) {
-		tests, err := findFailedTests("testdata/report.xml", map[string]string{"JOB_NAME": "job-name"}, 1)
+		tests, err := findFailedTests("testdata/report.xml", params{JobName: "job-name"}, 1)
 		assert.NoError(t, err)
 		assert.Equal(t, []testCase{
 			{
@@ -45,7 +45,7 @@ github.com/stackrox/rox/sensor/kubernetes/localscanner / TestLocalScannerTLSIssu
 		}, tests)
 	})
 	t.Run("dir multiple suites with threshold", func(t *testing.T) {
-		tests, err := findFailedTests("testdata", map[string]string{"JOB_NAME": "job-name", "BUILD_ID": "1"}, 3)
+		tests, err := findFailedTests("testdata", params{JobName: "job-name", BuildId: "1"}, 3)
 		assert.NoError(t, err)
 
 		assert.ElementsMatch(
@@ -67,7 +67,7 @@ command-line-arguments / TestTimeout FAILED
 		)
 	})
 	t.Run("dir", func(t *testing.T) {
-		tests, err := findFailedTests("testdata", map[string]string{"BUILD_ID": "1"}, 0)
+		tests, err := findFailedTests("testdata", params{BuildId: "1"}, 0)
 		assert.NoError(t, err)
 
 		assert.ElementsMatch(
@@ -140,7 +140,7 @@ command-line-arguments / TestTimeout FAILED
 		)
 	})
 	t.Run("gradle", func(t *testing.T) {
-		tests, err := findFailedTests("testdata/TEST-DefaultPoliciesTest.xml", map[string]string{"BUILD_ID": "1"}, 0)
+		tests, err := findFailedTests("testdata/TEST-DefaultPoliciesTest.xml", params{BuildId: "1"}, 0)
 		assert.NoError(t, err)
 
 		assert.Equal(
@@ -198,9 +198,10 @@ func TestDescription(t *testing.T) {
 			"?[1;30m21:36:16?[0;39m | ?[34mINFO ?[0;39m | Services                  | Failed to trigger Apache Struts: CVE-2017-5638 after waiting 60 seconds\n" +
 			"?[1;30m21:36:16?[0;39m | ?[1;31mERROR?[0;39m | Helpers                   | An exception occurred in test\n" +
 			"org.spockframework.runtime.ConditionNotSatisfiedError: Condition not satisfied:\n",
-		Stderr:  "",
-		Suite:   "DefaultPoliciesTest",
-		BuildId: "1",
+		Stderr:    "",
+		Suite:     "DefaultPoliciesTest",
+		BuildId:   "1",
+		BuildLink: "https://prow.ci.openshift.org/view/gs/origin-ci-test/logs//1",
 	}
 	actual, err := tc.description()
 	assert.NoError(t, err)
@@ -225,7 +226,6 @@ org.spockframework.runtime.ConditionNotSatisfiedError: Condition not satisfied:
 | BUILD ID     | [1|https://prow.ci.openshift.org/view/gs/origin-ci-test/logs//1]|
 | BUILD TAG    | [|]|
 | JOB NAME     ||
-| CLUSTER      ||
 | ORCHESTRATOR ||
 `, actual)
 	s, err := tc.summary()
@@ -253,7 +253,6 @@ waitForViolation(deploymentName,  policyName, 60)
 | BUILD ID     | [1|https://prow.ci.openshift.org/view/gs/origin-ci-test/logs//1]|
 | BUILD TAG    | [|]|
 | JOB NAME     ||
-| CLUSTER      ||
 | ORCHESTRATOR ||
 `, actual)
 }


### PR DESCRIPTION
In order to make our tool compatible with PROW and GHA, we need to extract the job environment properties. This will enable us to separate any workspace related logic from the tool, and ensure that the codebase remains consistent regardless of whether PROW or GHA is being used.