### PR TITLE
Convert junit2csv

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ go build ./...
 go test ./...
 ```
 
-### Usage
+### Usage example
 ```shell
 JIRA_TOKEN="..." junit2jira \
   -jira-url "https://..." \
@@ -22,5 +22,7 @@ JIRA_TOKEN="..." junit2jira \
   -build-link "https://..." \
   -build-tag "$STACKROX_BUILD_TAG|$GITHUB_SHA" \
   -job-name "$JOB_NAME|$GITHUB_WORKFLOW" \
-  -orchestrator "$ORCHESTRATOR_FLAVOR"
+  -orchestrator "$ORCHESTRATOR_FLAVOR" \
+  -timestamp $(date --rfc-3339=seconds)
+  -csv -
 ```

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ go build ./...
 go test ./...
 ```
 
-### Usage example
+### Example usage
 ```shell
 JIRA_TOKEN="..." junit2jira \
   -jira-url "https://..." \

--- a/README.md
+++ b/README.md
@@ -12,7 +12,37 @@ go build ./...
 go test ./...
 ```
 
-### Example usage
+### Usage
+
+```shell
+Usage of junit2jira:
+  -base-link string
+    	Link to source code at the exact version under test.
+  -build-id string
+    	Build job run ID.
+  -build-link string
+    	Link to build job.
+  -build-tag string
+    	Built tag or revision.
+  -csv-output string
+    	Convert XML to a CSV file (use dash [-] for stdout)
+  -dry-run
+    	When set to true issues will NOT be created.
+  -jira-url string
+    	Url of JIRA instance (default "https://issues.redhat.com/")
+  -job-name string
+    	Name of CI job.
+  -junit-reports-dir string
+    	Dir that contains jUnit reports XML files
+  -orchestrator string
+    	Orchestrator name (such as GKE or OpenShift), if any.
+  -threshold int
+    	Number of reported failures that should cause single issue creation. (default 10)
+  -timestamp string
+    	Timestamp of CI test. (default "2023-04-18T12:07:44+02:00")
+```
+
+## Example usage
 ```shell
 JIRA_TOKEN="..." junit2jira \
   -jira-url "https://..." \
@@ -24,5 +54,5 @@ JIRA_TOKEN="..." junit2jira \
   -job-name "$JOB_NAME|$GITHUB_WORKFLOW" \
   -orchestrator "$ORCHESTRATOR_FLAVOR" \
   -timestamp $(date --rfc-3339=seconds)
-  -csv -
+  -csv-output -
 ```

--- a/main.go
+++ b/main.go
@@ -28,7 +28,7 @@ ORDER BY created DESC`
 
 func main() {
 	p := params{}
-	flag.StringVar(&p.csvOutput, "csv", "", "Convert XML to a CSV file (use dash [-] for stdout)")
+	flag.StringVar(&p.csvOutput, "csv-output", "", "Convert XML to a CSV file (use dash [-] for stdout)")
 	flag.StringVar(&p.jiraUrl, "jira-url", "https://issues.redhat.com/", "Url of JIRA instance")
 	flag.StringVar(&p.junitReportsDir, "junit-reports-dir", os.Getenv("ARTIFACT_DIR"), "Dir that contains jUnit reports XML files")
 	flag.BoolVar(&p.dryRun, "dry-run", false, "When set to true issues will NOT be created.")


### PR DESCRIPTION
This PR adds the ability to parse junit and convert it to CSV with additional metadata passed as arguments. 
CSV could be saved to a file or STDOUT.

Once we merge junit2jira with https://github.com/stackrox/junit-parse we could think of adding commands and changing name of this tool so we will have something like:
- `junit2 jira` 
- `junit2 csv`
- `junit2 slack`
