### PR TITLE
fix invalid slack attachments

### DIFF
--- a/main.go
+++ b/main.go
@@ -639,10 +639,14 @@ func convertJunitToSlack(issues ...*testIssue) []slack.Attachment {
 
 		issue := i.issue
 		if issue != nil {
-			title = fmt.Sprintf("[**%s**](%s): %s", issue.Key, issue.Self, title)
+			title = fmt.Sprintf("%s: %s", issue.Key, title)
+		}
+		// Slack has a 150-character limit for text header
+		if len(title) > 150 {
+			title = title[:150]
 		}
 
-		titleTextBlock := slack.NewTextBlockObject("mrkdwn", title, false, false)
+		titleTextBlock := slack.NewTextBlockObject("plain_text", title, false, false)
 		titleSectionBlock := slack.NewSectionBlock(titleTextBlock, nil, nil)
 		failedTestsBlocks = append(failedTestsBlocks, titleSectionBlock)
 
@@ -700,7 +704,7 @@ func failureToAttachment(title string, tc testCase) (slack.Attachment, error) {
 	}
 
 	// Add some formatting to the failure title
-	failureTitleTextBlock := slack.NewTextBlockObject("mrkdwn", title, false, false)
+	failureTitleTextBlock := slack.NewTextBlockObject("plain_text", title, false, false)
 	failureTitleHeaderBlock := slack.NewHeaderBlock(failureTitleTextBlock)
 
 	failureAttachment := slack.Attachment{

--- a/testdata/slack/combined-expected.json
+++ b/testdata/slack/combined-expected.json
@@ -12,8 +12,8 @@
       {
         "type": "section",
         "text": {
-          "type": "mrkdwn",
-          "text": "[**FOO-1**](some/url/foo-1): MyTest: My Test Case 3"
+          "type": "plain_text",
+          "text": "FOO-1: MyTest: My Test Case 3"
         }
       }
     ]
@@ -24,8 +24,8 @@
       {
         "type": "header",
         "text": {
-          "type": "mrkdwn",
-          "text": "[**FOO-1**](some/url/foo-1): MyTest: My Test Case 3"
+          "type": "plain_text",
+          "text": "FOO-1: MyTest: My Test Case 3"
         }
       },
       {

--- a/testdata/slack/message-expected.json
+++ b/testdata/slack/message-expected.json
@@ -12,8 +12,8 @@
       {
         "type": "section",
         "text": {
-          "type": "mrkdwn",
-          "text": "[**FOO-1**](some/url/foo-1): MyTest: My Test Case 3"
+          "type": "plain_text",
+          "text": "FOO-1: MyTest: My Test Case 3"
         }
       }
     ]
@@ -24,8 +24,8 @@
       {
         "type": "header",
         "text": {
-          "type": "mrkdwn",
-          "text": "[**FOO-1**](some/url/foo-1): MyTest: My Test Case 3"
+          "type": "plain_text",
+          "text": "FOO-1: MyTest: My Test Case 3"
         }
       },
       {

--- a/testdata/slack/value-expected.json
+++ b/testdata/slack/value-expected.json
@@ -12,8 +12,8 @@
       {
         "type": "section",
         "text": {
-          "type": "mrkdwn",
-          "text": "[**FOO-1**](some/url/foo-1): MyTest: My Test Case 3"
+          "type": "plain_text",
+          "text": "FOO-1: MyTest: My Test Case 3"
         }
       }
     ]
@@ -24,8 +24,8 @@
       {
         "type": "header",
         "text": {
-          "type": "mrkdwn",
-          "text": "[**FOO-1**](some/url/foo-1): MyTest: My Test Case 3"
+          "type": "plain_text",
+          "text": "FOO-1: MyTest: My Test Case 3"
         }
       },
       {


### PR DESCRIPTION
Slack prohibits headers from being longer than 150 character and using markdown. This PR crops the header and changes jira link to plain text so message will be accepted. 

![image](https://github.com/stackrox/junit2jira/assets/1616386/6103045f-646c-4801-910a-c9cdd73593cd)
