### PR TITLE
Change log to use issue Key instead of ID

### DIFF
--- a/main.go
+++ b/main.go
@@ -320,7 +320,7 @@ func (j junit2jira) createIssueOrComment(tc testCase) (*testIssue, error) {
 		Body: description,
 	}
 
-	logEntry(issue.ID, issue.Fields.Summary).Info("Found issue. Creating a comment...")
+	logEntry(issue.Key, issue.Fields.Summary).Info("Found issue. Creating a comment...")
 
 	if j.dryRun {
 		logEntry(NA, issue.Fields.Summary).Debugf("Dry run: will just print comment:\n%q", description)


### PR DESCRIPTION
Noticed a log entry similar to:

```
... msg="Found issue. Creating a comment..." ID=87654321 ..."
```
The ID was unclear to which JIRA issue was found.  Logging the `ROX-*` key makes this logEntry consistent with the others next to it such that

```
ID=87654321
```
would be replaced by something similar to:
```
ID=ROX-12345
```