### PR TITLE
Avoid linking the same issues

### DIFF
--- a/main.go
+++ b/main.go
@@ -256,7 +256,8 @@ func (j junit2jira) linkIssues(issues []*jira.Issue) error {
 	var result error
 	for x, issue := range issues {
 		for y := 0; y < x; y++ {
-			// Skip cases where we have the same inward and outward issue
+			// Skip cases where we have the same inward and outward issue.
+			// Jira does not allow linking a ticket to itself.
 			if issue.Key == issues[y].Key {
 				continue
 			}

--- a/main.go
+++ b/main.go
@@ -256,6 +256,11 @@ func (j junit2jira) linkIssues(issues []*jira.Issue) error {
 	var result error
 	for x, issue := range issues {
 		for y := 0; y < x; y++ {
+			// Skip cases where we have the same inward and outward issue
+			if issue.Key == issues[y].Key {
+				continue
+			}
+
 			_, err := j.jiraClient.Issue.AddLink(&jira.IssueLink{
 				Type:         jira.IssueLinkType{Name: linkType},
 				OutwardIssue: &jira.Issue{Key: issue.Key},


### PR DESCRIPTION
This PR should fix errors where junit2jira will try to link an issue with itself.

An example: https://github.com/stackrox/stackrox/actions/runs/11819146919/job/32928382775?pr=13326
```
time="2024-11-13T14:49:43Z" level=info msg="Found 3 failed tests"
time="2024-11-13T14:49:44Z" level=info msg="Found issue. Creating a comment..." ID=ROX-22816 summary="github.com/stackrox/rox/pkg/grpc / Test_APIServerSuite FAILED"
time="2024-11-13T14:49:45Z" level=info msg="Found issue. Creating a comment..." ID=ROX-26980 summary="runtime.MemStats /  FAILED"
time="2024-11-13T14:49:46Z" level=info msg="Found issue. Creating a comment..." ID=ROX-26980 summary="runtime.MemStats /  FAILED"
time="2024-11-13T14:49:46Z" level=fatal msg="could not link issues: 1 error occurred:\n\t* You cannot link an issue to itself.: request failed. Please analyze the request body for more details. Status code: 400\n\n"
Error: Process completed with exit code 1.
```